### PR TITLE
Better leverage antora variables

### DIFF
--- a/content/antora.yml
+++ b/content/antora.yml
@@ -32,6 +32,8 @@ asciidoc:
     ocp-short: "OpenShift"
     argocd: "ArgoCD"
     ocp-gitops: "OpenShift GitOps"
+    ic-lab: "Lab"
+    ic: "Insurance Claim Processing Lab"
 
   extensions:
     - ./content/lib/tab-block.js

--- a/content/antora.yml
+++ b/content/antora.yml
@@ -4,7 +4,6 @@ version: ~
 nav:
   - modules/ROOT/nav.adoc
 
-
 asciidoc:
   attributes:
     release-version: dev
@@ -27,6 +26,12 @@ asciidoc:
     openshift_cluster_ingress_domain: PLACEHOLDER-URL.com
     rhoai_dashboard_url: https://rhods-dashboard-redhat-ods-applications.{openshift_cluster_ingress_domain}/
     login_command: oc login --insecure-skip-tls-verify=false -u userX -p openshift https://api.MYCLUSTER.com:6443"
+    rhoai: "Red Hat OpenShift AI"
+    rhoai-short: "RHOAI"
+    ocp: "OpenShift Container Platform"
+    ocp-short: "OpenShift"
+    argocd: "ArgoCD"
+    ocp-gitops: "OpenShift GitOps"
 
   extensions:
     - ./content/lib/tab-block.js

--- a/content/modules/ROOT/pages/01-01-setting-stage.adoc
+++ b/content/modules/ROOT/pages/01-01-setting-stage.adoc
@@ -1,7 +1,7 @@
 = Setting the stage
 include::_attributes.adoc[]
 
-In order to make this lab seem more realistic, we will be describing this imaginary scenario.
+In order to make this {ic} seem more realistic, we will be describing this imaginary scenario.
 
 == Situation
 :slide:

--- a/content/modules/ROOT/pages/02-01-getting-connected.adoc
+++ b/content/modules/ROOT/pages/02-01-getting-connected.adoc
@@ -1,7 +1,7 @@
 = Getting connected
 include::_attributes.adoc[]
 
-For the purposes of this training session, we have provisioned a single OpenShift cluster, with OpenShift AI deployed on it.
+For the purposes of this training session, we have provisioned a single {ocp} cluster, with {rhoai} deployed on it.
 
 Each person attending this lab will have a unique user account in which to do their work.
 
@@ -14,7 +14,7 @@ If you are using the customized version of the instructions, the information bel
 
 In a new window or tab, open the following URL and log in:
 
-* The Red Hat OpenShift AI Dashboard URL for our shared environment:
+* The {rhoai} URL for our shared environment:
 ** https://rhods-dashboard-redhat-ods-applications.{openshift_cluster_ingress_domain}/[https://rhods-dashboard-redhat-ods-applications.{openshift_cluster_ingress_domain}/,window=_blank]
 * Enter your credentials (as detailed above)
 * The result should look like:
@@ -33,7 +33,7 @@ image::02/02-01-login-scary.png[]
 [.bordershadow]
 image::02/02-01-rhoai-front-page.png[]
 
-If you got this far and saw all that, congratulations, you properly connected to the OpenShift AI Dashboard Application!
+If you got this far and saw all that, congratulations, you properly connected to the {rhoai} Dashboard Application!
 
 We are now ready to start the lab.
 

--- a/content/modules/ROOT/pages/02-01-getting-connected.adoc
+++ b/content/modules/ROOT/pages/02-01-getting-connected.adoc
@@ -14,7 +14,7 @@ If you are using the customized version of the instructions, the information bel
 
 In a new window or tab, open the following URL and log in:
 
-* The {rhoai} URL for our shared environment:
+* The {rhoai} Dashboard URL for our shared environment:
 ** https://rhods-dashboard-redhat-ods-applications.{openshift_cluster_ingress_domain}/[https://rhods-dashboard-redhat-ods-applications.{openshift_cluster_ingress_domain}/,window=_blank]
 * Enter your credentials (as detailed above)
 * The result should look like:

--- a/content/modules/ROOT/pages/02-01-getting-connected.adoc
+++ b/content/modules/ROOT/pages/02-01-getting-connected.adoc
@@ -35,7 +35,7 @@ image::02/02-01-rhoai-front-page.png[]
 
 If you got this far and saw all that, congratulations, you properly connected to the {rhoai} Dashboard Application!
 
-We are now ready to start the lab.
+We are now ready to start the {ic}.
 
 == Getting Support during RH1 In-Person Labs
 

--- a/content/modules/ROOT/pages/02-02-creating-project.adoc
+++ b/content/modules/ROOT/pages/02-02-creating-project.adoc
@@ -22,7 +22,7 @@ The instructions below will guide you through these steps. Follow them carefully
 
 == Create a project
 
-* First, in the OpenShift AI Dashboard application, navigate to the Data Science Projects menu on the left:
+* First, in the {rhoai} Dashboard application, navigate to the Data Science Projects menu on the left:
 +
 [.bordershadow]
 image::02/02-02-ds-proj-nav.png[]

--- a/content/modules/ROOT/pages/02-03-creating-workbench.adoc
+++ b/content/modules/ROOT/pages/02-03-creating-workbench.adoc
@@ -9,7 +9,7 @@ include::_attributes.adoc[]
 image::02/02-03-create-wb.png[]
 * Make sure it has the following characteristics:
 ** Choose a name for it, like: `My Workbench`
-** Image Selection: `CUSTOM - Insurance Claim Processing Lab Workbench`
+** Image Selection: `CUSTOM - {ic} Workbench`
 ** Container Size: `Standard`
 ** Accelerator: `None`
 * That should look like:

--- a/content/modules/ROOT/pages/02-04-validating-env.adoc
+++ b/content/modules/ROOT/pages/02-04-validating-env.adoc
@@ -33,7 +33,7 @@ Success: LLM Service is reachable on llm.ic-shared-llm.svc.cluster.local:3000
 Success: ModelMesh is reachable on modelmesh-serving.ic-shared-img-det.svc.cluster.local:8033
 ----
 
-If the output of this notebook looks suspicious, please inform the people leading the lab.
+If the output of this notebook looks suspicious, please inform the people leading the {ic}.
 
 == Overall view
 

--- a/content/modules/ROOT/pages/03-04-comparing-model-servers.adoc
+++ b/content/modules/ROOT/pages/03-04-comparing-model-servers.adoc
@@ -1,7 +1,7 @@
 = Comparing Model Servers
 include::_attributes.adoc[]
 
-So far, for this lab, we have used the model https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2[Mistral-7B Instruct v2,window=_blank]. Although lighter than other models, it is still quite heavy and we need a large GPU to run it. Would we get as good results with a quantized model (reduced in size) to run on CPU only? Let's try!
+So far, for this {ic-lab}, we have used the model https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2[Mistral-7B Instruct v2,window=_blank]. Although lighter than other models, it is still quite heavy and we need a large GPU to run it. Would we get as good results with a quantized model (reduced in size) to run on CPU only? Let's try!
 
 In this exercise, we'll pitch our previous model against the itself but in a quantized version. The values of the 7 Billion parameters used in the model have been "rounded", therefore loosing precision, but saving space. As it consumes now less memory, we are able to load it directly in a container and run it on a CPU. We'll compare the results and see if the quantized model is good enough for our use case.
 

--- a/content/modules/ROOT/pages/03-05-prompt-engineering.adoc
+++ b/content/modules/ROOT/pages/03-05-prompt-engineering.adoc
@@ -1,9 +1,9 @@
 = Prompt Engineering exercise (optional)
 include::_attributes.adoc[]
 
-NOTE: This part of the lab is marked as optional. It can therefore be skipped without effect on the other parts of the lab. You can always come back to it later at the end of the lab if you have time to spare.
+NOTE: This part of the {ic} is marked as optional. It can therefore be skipped without effect on the other parts of the lab. You can always come back to it later at the end of the {ic-lab} if you have time to spare.
 
-IMPORTANT: When you interact with ChatGPT or other commercial services, a lot of guardrails are in place to prevent you from getting unwanted  or not suitable for work results. In our Lab exercises, we are using a model that is not protected by those guardrails, and we will be modifying its settings. Therefore, it is your responsibility to do it in a safe way, and to make sure that the results you get are suitable for you and/or your audience. The authors of this Lab cannot be held responsible for any inappropriate results you may get.
+IMPORTANT: When you interact with ChatGPT or other commercial services, a lot of guardrails are in place to prevent you from getting unwanted  or not suitable for work results. In our {ic} exercises, we are using a model that is not protected by those guardrails, and we will be modifying its settings. Therefore, it is your responsibility to do it in a safe way, and to make sure that the results you get are suitable for you and/or your audience. The authors of this {ic} cannot be held responsible for any inappropriate results you may get.
 
 As you have seen in the previous sections, there are different factors that will influence the results you can get from your model: the model parameters, the prompt, the query, and of course the data itself...
 

--- a/content/modules/ROOT/pages/03-06-sanity-check.adoc
+++ b/content/modules/ROOT/pages/03-06-sanity-check.adoc
@@ -42,7 +42,7 @@ image::03/03-07-run-pipeline-ok.png[]
 We can also **schedule** an execution so that the sanity check is executed at regular intervals. +
 To do that:
 
-. Go back to the OpenShift AI Data Science Project
+. Go back to the {rhoai} Data Science Project
 . Find the pipeline you just ran
 . Click the 3 dots at the very end of the line, and click "Create run".
 +

--- a/content/modules/ROOT/pages/04-01-over-approach.adoc
+++ b/content/modules/ROOT/pages/04-01-over-approach.adoc
@@ -8,7 +8,7 @@ This model can be found online at https://www.yolov8.com[yolov8,window=_blank] a
 
 . We will first review its out-of-the-box capabilities. 
 . We will then fine-tune it to allow it to do more specialized work for us. 
-. Once we have a new, customized version of the model, we will deploy it in OpenShift AI Model Serving. 
+. Once we have a new, customized version of the model, we will deploy it in {rhoai} Model Serving. 
 . Once that is done, we will send queries to it.
 
 == Image Processing Out-of-the-box capabilities

--- a/content/modules/ROOT/pages/04-03-model-retraining.adoc
+++ b/content/modules/ROOT/pages/04-03-model-retraining.adoc
@@ -15,7 +15,7 @@ image::04/roboflow-test-images.png[roboflow images]
 3. Each image has an annotation text file in the 'labels' subfolder. The annotation text files have the same names as the image files.
 ====
 
-We have provided the following training data set, available as a zip file, and located in an S3 bucket: `accident-sample.zip` (as we don,t have time in this Lab to fully retrain the model, we will use a sample of the training data set).
+We have provided the following training data set, available as a zip file, and located in an S3 bucket: `accident-sample.zip` (as we don,t have time in this {ic-lab} to fully retrain the model, we will use a sample of the training data set).
 
 - In your running workbench, navigate to the folder `insurance-claim-processing/lab-materials/04`.
 - Look for (and open) the notebook called `04-03-model-retraining.ipynb`

--- a/content/modules/ROOT/pages/04-05-model-serving.adoc
+++ b/content/modules/ROOT/pages/04-05-model-serving.adoc
@@ -1,7 +1,7 @@
 = Model Serving
 include::_attributes.adoc[]
 
-. At this point, we need to deploy the model into RHOAI model serving.
+. At this point, we need to deploy the model into {rhoai-short} model serving.
 . We will create another Data Connection...
 .. With almost identical information
 .. But we will change the bucket name from `userX` to `models`

--- a/content/modules/ROOT/pages/05-01-application.adoc
+++ b/content/modules/ROOT/pages/05-01-application.adoc
@@ -37,11 +37,11 @@ image::05/05-toggle-off-workbench.jpg[]
 [.bordershadow]
 image::05/stop-workbench.png[]
 
-- In the image section, change the image to `CUSTOM - VSCode for Insurance Claim Processsing Lab`:
+- In the image section, change the image to `CUSTOM - VSCode for {ic}`:
 +
 [.bordershadow]
 image::05/05-change-to-vscode.jpg[]
-- Note that this is a Custom-built image added in this particular lab to illustrate the flexibility of the {rhoai} platform. Not everyone wants to use Jupyter Notebooks for everything.
+- Note that this is a Custom-built image added in this particular {ic-lab} to illustrate the flexibility of the {rhoai} platform. Not everyone wants to use Jupyter Notebooks for everything.
 
 - Then click on `Update workbench` at the bottom of the page:
 +

--- a/content/modules/ROOT/pages/05-01-application.adoc
+++ b/content/modules/ROOT/pages/05-01-application.adoc
@@ -12,17 +12,17 @@ image::05/application-architecture.drawio.svg[]
 The different components are:
 
 - The **frontend**: the application itself, developed using the Patternfly framework (React, Typescript), running in the browser of the user.
-- The **backend**: a Python FastAPI application, running in a container on OpenShift. It handles the communication with the database, the LLM, and the Object storage. It handles the communication with the frontend by exposing a REST API.
-- The **database**: a PostgreSQL database, running in a container on OpenShift. It stores the claims.
+- The **backend**: a Python FastAPI application, running in a container on {ocp}. It handles the communication with the database, the LLM, and the Object storage. It handles the communication with the frontend by exposing a REST API.
+- The **database**: a PostgreSQL database, running in a container on {ocp}. It stores the claims.
 - The **LLM**: the language model used to summarize and extract information from the claims. It is consumed by the backend through its API.
 - The **Object storage**: an S3-compatible object storage. It stores the claim images.
 
 == Application Code
 
-If you want to have a look at the code of the application, you can do it directly from OpenShift AI!
+If you want to have a look at the code of the application, you can do it directly from {rhoai}!
 
 - Close the different Jupyter tabs that may still be opened in your browser.
-- Go back to the OpenShift AI dashboard.
+- Go back to the {rhoai} Dashboard.
 - Stop your Workbench by using the toggle.
 
 +
@@ -41,7 +41,7 @@ image::05/stop-workbench.png[]
 +
 [.bordershadow]
 image::05/05-change-to-vscode.jpg[]
-- Note that this is a Custom-built image added in this particular lab to illustrate the flexibility of the OpenShift AI platform. Not everyone wants to use Jupyter Notebooks for everything.
+- Note that this is a Custom-built image added in this particular lab to illustrate the flexibility of the {rhoai} platform. Not everyone wants to use Jupyter Notebooks for everything.
 
 - Then click on `Update workbench` at the bottom of the page:
 +

--- a/content/modules/ROOT/pages/05-02-openshift-terminal.adoc
+++ b/content/modules/ROOT/pages/05-02-openshift-terminal.adoc
@@ -1,12 +1,12 @@
-= Working with the OpenShift Terminal
+= Working with the {ocp} Terminal
 include::_attributes.adoc[]
 
-To deploy the application, you will use the OpenShift Web Terminal. +
-This is a web-based terminal that allows you to execute commands on the OpenShift cluster from the OpenShift Console.
+To deploy the application, you will use the {ocp} Web Terminal. +
+This is a web-based terminal that allows you to execute commands on the {ocp-short} cluster from the {ocp-short} Console.
 
-== Opening the OpenShift Console
+== Opening the {ocp} Console
 
-- Access the OpenShift Console via this link:
+- Access the {ocp-short} Console via this link:
 +
 [.bordershadow]
 image::05/01-openshift-console.png[]
@@ -15,7 +15,7 @@ image::05/01-openshift-console.png[]
 
 == Open a Web Terminal
 
-- On the OpenShift Console, click on the Web Terminal icon in the top right corner:
+- On the {ocp-short} Console, click on the Web Terminal icon in the top right corner:
 +
 [.bordershadow]
 image::05/web-term-1.png[]

--- a/content/modules/ROOT/pages/05-03-web-app-deploy-application.adoc
+++ b/content/modules/ROOT/pages/05-03-web-app-deploy-application.adoc
@@ -1,12 +1,12 @@
 = Deploying the application via GitOps
 include::_attributes.adoc[]
 
-== Deploy your instance of ArgoCD
+== Deploy your instance of {argocd}
 
 We will start by deploying an instance of ArgoCD in your namespace. +
 This will be used to deploy the application.
 
-- Copy the following text, and paste it in the OpenShift Terminal to deploy ArgoCD.
+- Copy the following text, and paste it in the {ocp-short} Terminal to deploy {argocd}.
 +
 [.lines_space]
 [.console-input]
@@ -42,7 +42,7 @@ spec:
         termination: edge
 EOF
 
-- Still in the Terminal, run the following command to check the status of the ArgoCD deployment.
+- Still in the Terminal, run the following command to check the status of the {argocd} deployment.
 +
 [.lines_space]
 [.console-input]
@@ -54,17 +54,17 @@ oc rollout status deploy/argocd-server
 [.bordershadow]
 image::05/argocd-rollout.png[]
 
-**Optional**: If you know and understand ArgoCD and want to look at its interface, look at the following details. Otherwise, you can skip to the next step.
+**Optional**: If you know and understand {argocd} and want to look at its interface, look at the following details. Otherwise, you can skip to the next step.
 [%collapsible]
 ====
 Now that Argo is deployed, you can connect to its UI through its Route.
 
-- Let's find the Route of the ArgoCD instance by running the following command in the Terminal:
+- Let's find the Route of the {argocd} instance by running the following command in the Terminal:
 +
 [.lines_space]
 [.console-input]
 [source, text]
-echo "   ArgoCD UI : https://$(oc get route argocd-server -ojsonpath='{.status.ingress[0].host}')/ "
+echo "   {argocd} UI : https://$(oc get route argocd-server -ojsonpath='{.status.ingress[0].host}')/ "
 
 - You should obtain something like this:
 +
@@ -76,9 +76,9 @@ image::05/argocd-route.png[]
 
 == Deploy the application(s) via GitOps
 
-Now that ArgoCD is deployed in your namespace, we can use it to deploy the application via GitOps.
+Now that {argocd} is deployed in your namespace, we can use it to deploy the application via GitOps.
 
-- Copy the content of the following text, and paste it in the OpenShift Terminal to deploy the application.
+- Copy the content of the following text, and paste it in the {ocp-short} Terminal to deploy the application.
 +
 [.lines_space]
 [.console-input]

--- a/content/modules/ROOT/pages/05-05-process-claims.adoc
+++ b/content/modules/ROOT/pages/05-05-process-claims.adoc
@@ -39,7 +39,7 @@ NOTE: In the folder, we still have for reference an Elyra version of the pipelin
 
 Before we can run the pipeline, we need to create a PVC that will be used to store intermediary files and results in. +
 
-* Go to the OpenShift Console
+* Go to the {ocp-short} Console
 * Make sure and change your view from **Developer** to **Administrator**
 +
 [.bordershadow]
@@ -93,7 +93,7 @@ image::05/05-PVC-settings.png[PVC settings]
 * Start by downloading the `process_claims.yaml` file locally to your laptop
 ** In your VSCode Workbench, right click on the file, and select **Download**
 ** Save the file somewhere on your laptop
-* Then go to the Red Hat OpenShift Data Science dashboard
+* Then go to the {rhoai} Dashboard
 * Select your Data Science project
 * Scroll down until you see the **Pipelines** section
 * Click **Import Pipeline**

--- a/content/modules/ROOT/pages/06-01-potential-imp-ref.adoc
+++ b/content/modules/ROOT/pages/06-01-potential-imp-ref.adoc
@@ -1,15 +1,15 @@
 = Potential Improvements and Refinements
 include::_attributes.adoc[]
 
-== To the lab materials
+== To the {ic} materials
 
-If you have any feedback regarding this Lab, please use https://github.com/rh-aiservices-bu/insurance-claim-processing/issues[Issues,window=_blank] and https://github.com/rh-aiservices-bu/insurance-claim-processing/pulls[Pull Requests,window=_blank].
+If you have any feedback regarding this {ic}, please use https://github.com/rh-aiservices-bu/insurance-claim-processing/issues[Issues,window=_blank] and https://github.com/rh-aiservices-bu/insurance-claim-processing/pulls[Pull Requests,window=_blank].
 
-But this section of the lab is not meant for Improvements and Refinements **to the lab**. Instead it is about...
+But this section of the {ic} is not meant for Improvements and Refinements **to the lab**. Instead it is about...
 
 == To the presented prototype
 
-What we have shown in this lab is a very rough prototype, put together very quickly, in order to demonstrate:
+What we have shown in this {ic} is a very rough prototype, put together very quickly, in order to demonstrate:
 
 * Which improvements could be done
 * How long it would take to do them

--- a/content/modules/ROOT/pages/06-02-applicability-other.adoc
+++ b/content/modules/ROOT/pages/06-02-applicability-other.adoc
@@ -1,7 +1,7 @@
 = Applicability to other industries
 include::_attributes.adoc[]
 
-Now, the examples we've shown throughout this lab are specific to the Insurance industry, and within that, claims processing.
+Now, the examples we've shown throughout this {ic} are specific to the Insurance industry, and within that, claims processing.
 
 However, none of the techniques we used here are inherently related to this industry or this use-case.
 

--- a/content/modules/ROOT/pages/07-01-end-of-lab.adoc
+++ b/content/modules/ROOT/pages/07-01-end-of-lab.adoc
@@ -5,8 +5,8 @@ We hope that the materials we used during this time together were useful and gav
 
 If you notice https://github.com/rh-aiservices-bu/insurance-claim-processing/issues[issues,window=_blank] with the content and/or want to send us a https://github.com/rh-aiservices-bu/insurance-claim-processing/pulls[pull request,window=_blank], we'll appreciate it very much.
 
-The instructions of this lab are always available at https://rh-aiservices-bu.github.io/insurance-claim-processing/[https://rh-aiservices-bu.github.io/insurance-claim-processing/,window=_blank]. Make note of this URL as it will be updated with new content as we continue to improve the lab.
+The instructions of this {ic} are always available at https://rh-aiservices-bu.github.io/insurance-claim-processing/[https://rh-aiservices-bu.github.io/insurance-claim-processing/,window=_blank]. Make note of this URL as it will be updated with new content as we continue to improve the {ic-lab}.
 
 == Acknowledgements
 
-Thanks to everyone who helped create this lab, https://github.com/rh-aiservices-bu/insurance-claim-processing/graphs/contributors[contributors,window=_blank] and reviewers!
+Thanks to everyone who helped create this {ic}, https://github.com/rh-aiservices-bu/insurance-claim-processing/graphs/contributors[contributors,window=_blank] and reviewers!

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -9,9 +9,9 @@ The information, code, models and techniques it contains are illustrations of wh
 
 == Disclaimer
 
-This lab is an example of what a customer could build using OpenShift AI. OpenShift AI has no specific feature related to Insurance Claim Processing.
+This lab is an example of what a customer could build using {rhoai}. {rhoai} has no specific feature related to Insurance Claim Processing.
 
-This lab makes use of large language models (LLM) and image processing models. These models are not included in the OpenShift AI product. They are provided as a convenience for this lab.
+This lab makes use of large language models (LLM) and image processing models. These models are not included in the {rhoai} product. They are provided as a convenience for this lab.
 
 The quality of these models is enough for a prototype. Choosing the right model to use in a production environment is a complex task that requires a lot of experimentation and tuning. This lab does not cover this aspect.
 

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -1,19 +1,19 @@
 = {lab_name}
 include::_attributes.adoc[]
 
-== Lab Overview
+== {ic} Overview
 
-This lab will illustrate how the use of various AI/ML technologies can be combined to produce a valuable solution to a business problem.
+This {ic} will illustrate how the use of various AI/ML technologies can be combined to produce a valuable solution to a business problem.
 
 The information, code, models and techniques it contains are illustrations of what a first prototype could look like. It is not the definitive way of addressing the stated requirements.
 
 == Disclaimer
 
-This lab is an example of what a customer could build using {rhoai}. {rhoai} has no specific feature related to Insurance Claim Processing.
+This {ic} is an example of what a customer could build using {rhoai}. {rhoai} has no specific feature related to Insurance Claim Processing.
 
-This lab makes use of large language models (LLM) and image processing models. These models are not included in the {rhoai} product. They are provided as a convenience for this lab.
+This {ic-lab} makes use of large language models (LLM) and image processing models. These models are not included in the {rhoai} product. They are provided as a convenience for this {ic-lab}.
 
-The quality of these models is enough for a prototype. Choosing the right model to use in a production environment is a complex task that requires a lot of experimentation and tuning. This lab does not cover this aspect.
+The quality of these models is enough for a prototype. Choosing the right model to use in a production environment is a complex task that requires a lot of experimentation and tuning. This {ic-lab} does not cover this aspect.
 
 == Timetable
 


### PR DESCRIPTION
To fix the https://github.com/rh-aiservices-bu/insurance-claim-processing/issues/157 issue, we leverage some Antora variables and use them in the lab content pages.

- Tested locally with lab-build / lab-serve to check the render.
- Added the following Antora vars:
  - rhoai: "Red Hat OpenShift AI"
  - rhoai-short: "RHOAI"
  - ocp: "OpenShift Container Platform"
  - ocp-short: "OpenShift"
  - argocd: "ArgoCD"
  - ocp-gitops: "OpenShift GitOps"
  - ic-lab: "Lab"
  - ic: "Insurance Claim Processing Lab"